### PR TITLE
refactor: change arguments for `cumulative_dose_filter_3d`

### DIFF
--- a/tests/dose_weight/test_dose_weight.py
+++ b/tests/dose_weight/test_dose_weight.py
@@ -2,7 +2,7 @@ import torch
 
 from torch_fourier_filter.dose_weight import (
     critical_exposure,
-    critical_exposure_Bfac,
+    critical_exposure_bfactor,
     cumulative_dose_filter_3d,
 )
 
@@ -16,57 +16,56 @@ def test_critical_exposure():
     ), "critical_exposure output mismatch"
 
 
-def test_critical_exposure_Bfac():
+def test_critical_exposure_bfactor():
     fft_freq = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5])
-    Bfac = 1.0
+    bfac = 1.0
     expected_output = torch.tensor([200.0, 50.0, 22.222, 12.5, 8.0])
-    output = critical_exposure_Bfac(fft_freq, Bfac)
+    output = critical_exposure_bfactor(fft_freq, bfac)
     assert torch.allclose(
         output, expected_output, atol=1e-3
-    ), "critical_exposure_Bfac output mismatch"
+    ), "critical_exposure_bfactor output mismatch"
 
 
 def test_cumulative_dose_filter_3d():
     # Test parameters
     volume_shape = (32, 32, 32)
-    num_frames = 10
     start_exposure = 0.0
+    end_exposure = 10.0
     pixel_size = 1.0
-    flux = 1.0
-    Bfac = -1.0
+    crit_exposure_bfactor = -1
     rfft = True
     fftshift = False
 
     # Call the function
     dose_filter = cumulative_dose_filter_3d(
         volume_shape=volume_shape,
-        num_frames=num_frames,
-        start_exposure=start_exposure,
         pixel_size=pixel_size,
-        flux=flux,
-        Bfac=Bfac,
+        start_exposure=start_exposure,
+        end_exposure=end_exposure,
+        crit_exposure_bfactor=crit_exposure_bfactor,
         rfft=rfft,
         fftshift=fftshift,
     )
 
     # Check if the values are within a reasonable range
+    # TODO: Test these against known, static values rather than just range
     assert torch.all(dose_filter >= 0) and torch.all(
         dose_filter <= 1
     ), "Dose filter values out of range"
 
-    # Test with different Bfac values
-    Bfac_values = [0.5, 1.0, 2.0]
-    for Bfac in Bfac_values:
+    # Test with different bfac values
+    # TODO: Test these against known, static values rather than just range
+    crit_bfac_values = [0.5, 1.0, 2.0]
+    for bfac in crit_bfac_values:
         dose_filter = cumulative_dose_filter_3d(
             volume_shape=volume_shape,
-            num_frames=num_frames,
-            start_exposure=start_exposure,
             pixel_size=pixel_size,
-            flux=flux,
-            Bfac=Bfac,
+            start_exposure=start_exposure,
+            end_exposure=end_exposure,
+            crit_exposure_bfactor=bfac,
             rfft=rfft,
             fftshift=fftshift,
         )
         assert torch.all(dose_filter >= 0) and torch.all(
             dose_filter <= 1
-        ), f"Dose filter values out of range for Bfac={Bfac}"
+        ), f"Dose filter values out of range for bfac={bfac}"


### PR DESCRIPTION
- Changes the total exposure calculation in `dose_weight.cumulative_dose_filter_3d` from using number of frames and electron fluence to just using `start_exposure` and `end_exposure`.
- Changes `Bfac` argument to `crit_exposure_bfactor` for increased verbosity. No functionality changes follow.